### PR TITLE
Define a yaml loader when loading a YAML file

### DIFF
--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -39,7 +39,9 @@ class DagFactory:
         :returns: dict from YAML config file
         """
         try:
-            config: Dict[str, Any] = yaml.load(stream=open(config_filepath, "r"))
+            config: Dict[str, Any] = yaml.load(
+                stream=open(config_filepath, "r"), Loader=yaml.FullLoader
+            )
         except Exception as err:
             raise Exception(f"Invalid DAG Factory config file; err: {err}")
         return config


### PR DESCRIPTION
We can fix the following warning.
> lib/python3.6/site-packages/dagfactory/dagfactory.py:42: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.