### PR TITLE
Permit setting 'None' as valid schedule interval

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -132,7 +132,9 @@ class DagBuilder:
         dag_params: Dict[str, Any] = self.get_dag_params()
         dag: DAG = DAG(
             dag_id=dag_params["dag_id"],
-            schedule_interval=None if dag_params["schedule_interval"] == 'None' else dag_params["schedule_interval"],
+            schedule_interval=None
+            if dag_params["schedule_interval"] == "None"
+            else dag_params["schedule_interval"],
             description=dag_params.get("description", ""),
             concurrency=dag_params.get(
                 "concurrency", configuration.conf.getint("core", "dag_concurrency"),

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -132,7 +132,7 @@ class DagBuilder:
         dag_params: Dict[str, Any] = self.get_dag_params()
         dag: DAG = DAG(
             dag_id=dag_params["dag_id"],
-            schedule_interval=dag_params["schedule_interval"],
+            schedule_interval=None if dag_params["schedule_interval"] == 'None' else dag_params["schedule_interval"],
             description=dag_params.get("description", ""),
             concurrency=dag_params.get(
                 "concurrency", configuration.conf.getint("core", "dag_concurrency"),


### PR DESCRIPTION
When defining DAGs the schedule_interval param is read in as string.
This way, setting 'None' as schedule_interval is not possible, as it is no valid cron expression.
With this patch it is possible to define DAGs that never get scheduled automatically. 