### PR TITLE
Fix 'tags' error

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -158,7 +158,7 @@ class DagBuilder:
             on_success_callback=dag_params.get("on_success_callback", None),
             on_failure_callback=dag_params.get("on_failure_callback", None),
             default_args=dag_params.get("default_args", {}),
-            tags=dag_params.get("tags", {}),
+            tags=dag_params.get("tags", None),
         )
         tasks: Dict[str, Dict[str, Any]] = dag_params["tasks"]
 


### PR DESCRIPTION
The default value of 'tags' should be 'None'. See https://github.com/apache/airflow/blob/c41192fa1fc5c2b3e7b8414c59f656ab67bbef28/airflow/models/dag.py#L236.