### PR TITLE
Check date_value types explicitly in get_datetime

### DIFF
--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -29,11 +29,11 @@ def get_datetime(
         local_tz: pendulum.Timezone = pendulum.timezone(timezone)
     except Exception as err:
         raise Exception(f"Failed to create timezone; err: {err}")
-    if isinstance(date_value, date):
+    if type(date_value) is date:
         return datetime.combine(date=date_value, time=datetime.min.time()).replace(
             tzinfo=local_tz
         )
-    if isinstance(date_value, datetime):
+    if type(date_value) is datetime:
         return date_value.replace(tzinfo=local_tz)
     rel_delta: timedelta = get_time_delta(date_value)
     now: datetime = (

--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -29,11 +29,11 @@ def get_datetime(
         local_tz: pendulum.Timezone = pendulum.timezone(timezone)
     except Exception as err:
         raise Exception(f"Failed to create timezone; err: {err}")
-    if type(date_value) is date:
+    if type(date_value) is date:  # pylint: disable=unidiomatic-typecheck
         return datetime.combine(date=date_value, time=datetime.min.time()).replace(
             tzinfo=local_tz
         )
-    if type(date_value) is datetime:
+    if type(date_value) is datetime:  # pylint: disable=unidiomatic-typecheck
         return date_value.replace(tzinfo=local_tz)
     rel_delta: timedelta = get_time_delta(date_value)
     now: datetime = (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,8 +19,8 @@ def test_get_start_date_date_no_timezone():
 
 
 def test_get_start_date_datetime_no_timezone():
-    expected = datetime.datetime(2018, 2, 1, 0, 0, tzinfo=UTC)
-    actual = utils.get_datetime(datetime.datetime(2018, 2, 1))
+    expected = datetime.datetime(2018, 2, 1, 5, 4, tzinfo=UTC)
+    actual = utils.get_datetime(datetime.datetime(2018, 2, 1, 5, 4))
     assert actual == expected
 
 


### PR DESCRIPTION
__What__

Check the type of `date_value` passed to `get_datetime` in order to preserve the time component.


__Why__

Since `datetime.datetime` is a subclass of `datetime.date, using `isinstance on and instance of either class will return True. Using `type` will return the exact class.

Closes: #42