### PR TITLE
Catchup parameter added to dag options.

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -222,7 +222,8 @@ class DagBuilder:
                 configuration.conf.getint("core", "dag_concurrency"),
             ),
             catchup=dag_params.get(
-                "catchup", configuration.conf.getboolean("scheduler", "catchup_by_default"),
+                "catchup",
+                configuration.conf.getboolean("scheduler", "catchup_by_default"),
             ),
             max_active_runs=dag_params.get(
                 "max_active_runs",

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -221,6 +221,9 @@ class DagBuilder:
                 "concurrency",
                 configuration.conf.getint("core", "dag_concurrency"),
             ),
+            catchup=dag_params.get(
+                "catchup", configuration.conf.getboolean("scheduler", "catchup_by_default"),
+            ),
             max_active_runs=dag_params.get(
                 "max_active_runs",
                 configuration.conf.getint("core", "max_active_runs_per_dag"),


### PR DESCRIPTION
Catchup is not work when added as default args. That's why need to be added as dag parameters.
See https://stackoverflow.com/questions/54902270/apache-airflow-setting-catchup-to-false-is-not-working