### PR TITLE
ExternalTaskSensor Support added.

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -187,7 +187,22 @@ class DagBuilder:
                     seconds=task_params["execution_timeout_secs"]
                 )
                 del task_params["execution_timeout_secs"]
+            
+            if utils.check_dict_key(task_params, "execution_delta_secs"):
+                task_params["execution_delta"]: timedelta = timedelta(
+                    seconds=task_params["execution_delta_secs"]
+                )
+                del task_params["execution_delta_secs"]
 
+            if utils.check_dict_key(task_params, "execution_date_fn_name") and utils.check_dict_key(task_params, "execution_date_fn_file"):
+                task_params["execution_date_fn"]: Callable = utils.get_python_callable(
+                    task_params["execution_date_fn_name"],
+                    task_params["execution_date_fn_file"],
+                )
+                del task_params["execution_date_fn_name"]
+                del task_params["execution_date_fn_file"]
+                
+            
             # use variables as arguments on operator
             if utils.check_dict_key(task_params, "variables_as_arguments"):
                 variables: List[Dict[str, str]] = task_params.get(

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -194,7 +194,8 @@ class DagBuilder:
                 )
                 del task_params["execution_delta_secs"]
 
-            if utils.check_dict_key(task_params, "execution_date_fn_name") and utils.check_dict_key(task_params, "execution_date_fn_file"):
+            if utils.check_dict_key(task_params, "execution_date_fn_name") and \
+                    utils.check_dict_key(task_params, "execution_date_fn_file"):
                 task_params["execution_date_fn"]: Callable = utils.get_python_callable(
                     task_params["execution_date_fn_name"],
                     task_params["execution_date_fn_file"],

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -187,23 +187,23 @@ class DagBuilder:
                     seconds=task_params["execution_timeout_secs"]
                 )
                 del task_params["execution_timeout_secs"]
-            
+
             if utils.check_dict_key(task_params, "execution_delta_secs"):
                 task_params["execution_delta"]: timedelta = timedelta(
                     seconds=task_params["execution_delta_secs"]
                 )
                 del task_params["execution_delta_secs"]
 
-            if utils.check_dict_key(task_params, "execution_date_fn_name") and \
-                    utils.check_dict_key(task_params, "execution_date_fn_file"):
+            if utils.check_dict_key(
+                task_params, "execution_date_fn_name"
+            ) and utils.check_dict_key(task_params, "execution_date_fn_file"):
                 task_params["execution_date_fn"]: Callable = utils.get_python_callable(
                     task_params["execution_date_fn_name"],
                     task_params["execution_date_fn_file"],
                 )
                 del task_params["execution_date_fn_name"]
                 del task_params["execution_date_fn_file"]
-                
-            
+
             # use variables as arguments on operator
             if utils.check_dict_key(task_params, "variables_as_arguments"):
                 variables: List[Dict[str, str]] = task_params.get(


### PR DESCRIPTION
execution_delta is timedelta and should be passed as execution_delta_secs 
execution_delta_fn is callable and should be passed as execution_delta_fn_file (filename) and execution_delta_fn_name(function name)

More info: https://airflow.apache.org/docs/stable/_api/airflow/sensors/external_task_sensor/index.html