### PR TITLE
Handle "None" more flexibly as the value of schedule_interval

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -67,6 +67,12 @@ class DagBuilder:
             raise "Failed to merge config with default config" from err
         dag_params["dag_id"]: str = self.dag_name
 
+        if (
+            utils.check_dict_key(dag_params, "schedule_interval")
+            and dag_params["schedule_interval"] == "None"
+        ):
+            dag_params["schedule_interval"] = None
+
         # Convert from 'dagrun_timeout_sec: int' to 'dagrun_timeout: timedelta'
         if utils.check_dict_key(dag_params, "dagrun_timeout_sec"):
             dag_params["dagrun_timeout"]: timedelta = timedelta(
@@ -235,8 +241,8 @@ class DagBuilder:
         dag_params: Dict[str, Any] = self.get_dag_params()
         dag: DAG = DAG(
             dag_id=dag_params["dag_id"],
-            schedule_interval=dag_params["schedule_interval"],
-            description=dag_params.get("description", ""),
+            schedule_interval=dag_params.get("schedule_interval", timedelta(days=1)),
+            description=dag_params.get("description", None),
             concurrency=dag_params.get(
                 "concurrency",
                 configuration.conf.getint("core", "dag_concurrency"),
@@ -259,7 +265,7 @@ class DagBuilder:
             ),
             on_success_callback=dag_params.get("on_success_callback", None),
             on_failure_callback=dag_params.get("on_failure_callback", None),
-            default_args=dag_params.get("default_args", {}),
+            default_args=dag_params.get("default_args", None),
             doc_md=dag_params.get("doc_md", None),
         )
 

--- a/tests/fixtures/dag_factory.yml
+++ b/tests/fixtures/dag_factory.yml
@@ -34,6 +34,7 @@ example_dag:
       operator: airflow.operators.bash_operator.BashOperator
 example_dag2:
   doc_md_file_path: {here}/fixtures/mydocfile.md
+  schedule_interval: None
   tasks:
     task_1:
       bash_command: echo 1

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -79,6 +79,7 @@ def test_load_config_valid():
         },
         "example_dag2": {
             "doc_md_file_path" : DOC_MD_FIXTURE_FILE,
+            "schedule_interval": "None",
             "tasks": {
                 "task_1": {
                     "operator": "airflow.operators.bash_operator.BashOperator",
@@ -146,6 +147,7 @@ def test_get_dag_configs():
         },
         "example_dag2": {
             "doc_md_file_path": DOC_MD_FIXTURE_FILE,
+            "schedule_interval": "None",
             "tasks": {
                 "task_1": {
                     "operator": "airflow.operators.bash_operator.BashOperator",
@@ -259,3 +261,9 @@ def test_doc_md_callable():
     td.generate_dags(globals())
     expected_doc_md = globals()['example_dag3'].doc_md
     assert str(td.get_dag_configs()['example_dag3']['doc_md_python_arguments']) == expected_doc_md
+
+def test_schedule_interval():
+    td = dagfactory.DagFactory(TEST_DAG_FACTORY)
+    td.generate_dags(globals())
+    schedule_interval = globals()['example_dag2'].schedule_interval
+    assert schedule_interval is None


### PR DESCRIPTION
If the yaml file we created looks like this:
```
test1: None
test2: null
test3: "None"
```
YAML Loader reads as follows.
```
{'test1':'None','test2': None,'test3':'None'}
```
In this case, it would be better to handle "None" more flexibly
because Airflow doesn't allow "None" as schedule_interval.
Please refer https://airflow.apache.org/docs/apache-airflow/1.10.10/scheduler.html#dag-runs.