### PR TITLE
Airflow sets different default value of the 'description' depending on the version

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -292,9 +292,9 @@ class DagBuilder:
 
         # The default value of description parameter was changed since Airflow 1.10.11
         if version.parse(AIRFLOW_VERSION) >= version.parse("1.10.11"):
-            dag.description = dag_params.get("description", None)
+            dag._description = dag_params.get("description", None)
         else:
-            dag.description = dag_params.get("description", "")
+            dag._description = dag_params.get("description", "")
 
         tasks: Dict[str, Dict[str, Any]] = dag_params["tasks"]
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -242,7 +242,6 @@ class DagBuilder:
         dag: DAG = DAG(
             dag_id=dag_params["dag_id"],
             schedule_interval=dag_params.get("schedule_interval", timedelta(days=1)),
-            description=dag_params.get("description", None),
             concurrency=dag_params.get(
                 "concurrency",
                 configuration.conf.getint("core", "dag_concurrency"),
@@ -290,6 +289,12 @@ class DagBuilder:
         # tags parameter introduced in Airflow 1.10.8
         if version.parse(AIRFLOW_VERSION) >= version.parse("1.10.8"):
             dag.tags = dag_params.get("tags", None)
+
+        # The default value of description parameter was changed since Airflow 1.10.11
+        if version.parse(AIRFLOW_VERSION) >= version.parse("1.10.11"):
+            dag.description = dag_params.get("description", None)
+        else:
+            dag.description = dag_params.get("description", "")
 
         tasks: Dict[str, Dict[str, Any]] = dag_params["tasks"]
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -242,6 +242,11 @@ class DagBuilder:
         dag: DAG = DAG(
             dag_id=dag_params["dag_id"],
             schedule_interval=dag_params.get("schedule_interval", timedelta(days=1)),
+            description=(
+                dag_params.get("description", None)
+                if version.parse(AIRFLOW_VERSION) >= version.parse("1.10.11")
+                else dag_params.get("description", "")
+            ),
             concurrency=dag_params.get(
                 "concurrency",
                 configuration.conf.getint("core", "dag_concurrency"),
@@ -289,12 +294,6 @@ class DagBuilder:
         # tags parameter introduced in Airflow 1.10.8
         if version.parse(AIRFLOW_VERSION) >= version.parse("1.10.8"):
             dag.tags = dag_params.get("tags", None)
-
-        # The default value of description parameter was changed since Airflow 1.10.11
-        if version.parse(AIRFLOW_VERSION) >= version.parse("1.10.11"):
-            dag._description = dag_params.get("description", None)
-        else:
-            dag._description = dag_params.get("description", "")
 
         tasks: Dict[str, Dict[str, Any]] = dag_params["tasks"]
 


### PR DESCRIPTION
* Airflow 1.10.10 uses `''` as default value. https://github.com/apache/airflow/blob/1.10.10/airflow/models/dag.py#L218
* Airflow 1.10.11 uses `None` as default value. https://github.com/apache/airflow/blob/1.10.11/airflow/models/dag.py#L221