### PR TITLE
pin sql-alchemy and flask-sqlalchemy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
 deps = 
     pytest
     pytest-cov
-    apache-airflow[kubernetes] >=2.0.0
+    apache-airflow[cncf.kubernetes] >=2.0.0
     SQLAlchemy==1.3.23
     Flask-SQLAlchemy==2.4.4
 setenv =
@@ -81,7 +81,7 @@ commands =
 deps = 
     pytest
     pytest-cov
-    apache-airflow[kubernetes] >=2.0.0
+    apache-airflow[cncf.kubernetes] >=2.0.0
     SQLAlchemy==1.3.23
     Flask-SQLAlchemy==2.4.4
 setenv =
@@ -121,7 +121,7 @@ commands =
 deps = 
     pytest
     pytest-cov
-    apache-airflow[kubernetes] >=2.0.0
+    apache-airflow[cncf.kubernetes] >=2.0.0
     SQLAlchemy==1.3.23
     Flask-SQLAlchemy==2.4.4
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
     pytest-cov
     apache-airflow[kubernetes] >=1.10.0, <=1.10.6
     werkzeug<1.0.0
+    SQLAlchemy==1.3.23 
+	Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1106.db
 commands =
@@ -27,6 +29,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=1.10.8, <2.0.0
+    SQLAlchemy==1.3.23 
+	Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1108.db
 commands =
@@ -38,6 +42,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=2.0.0
+    SQLAlchemy==1.3.23 
+	Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow2.db
 commands =
@@ -50,6 +56,8 @@ deps =
     pytest-cov
     apache-airflow[kubernetes] >=1.10.0, <=1.10.6
     werkzeug<1.0.0
+    SQLAlchemy==1.3.23 
+	Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1106.db
 commands =
@@ -61,6 +69,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=1.10.8, <2.0.0
+    SQLAlchemy==1.3.23 
+	Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1108.db
 commands =
@@ -72,6 +82,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=2.0.0
+    SQLAlchemy==1.3.23 
+	Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow2.db
 commands =
@@ -84,6 +96,8 @@ deps =
     pytest-cov
     apache-airflow[kubernetes] >=1.10.0, <=1.10.6
     werkzeug<1.0.0
+    SQLAlchemy==1.3.23 
+	Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1106.db
 commands =
@@ -95,6 +109,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=1.10.8, <2.0.0
+    SQLAlchemy==1.3.23 
+	Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1108.db
 commands =
@@ -106,6 +122,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=2.0.0
+    SQLAlchemy==1.3.23 
+	Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow2.db
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ deps =
     pytest-cov
     apache-airflow[kubernetes] >=1.10.0, <=1.10.6
     werkzeug<1.0.0
-    SQLAlchemy==1.3.23 
-	Flask-SQLAlchemy==2.4.4
+    SQLAlchemy==1.3.23
+    Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1106.db
 commands =
@@ -29,8 +29,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=1.10.8, <2.0.0
-    SQLAlchemy==1.3.23 
-	Flask-SQLAlchemy==2.4.4
+    SQLAlchemy==1.3.23
+    Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1108.db
 commands =
@@ -42,8 +42,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=2.0.0
-    SQLAlchemy==1.3.23 
-	Flask-SQLAlchemy==2.4.4
+    SQLAlchemy==1.3.23
+    Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow2.db
 commands =
@@ -56,8 +56,8 @@ deps =
     pytest-cov
     apache-airflow[kubernetes] >=1.10.0, <=1.10.6
     werkzeug<1.0.0
-    SQLAlchemy==1.3.23 
-	Flask-SQLAlchemy==2.4.4
+    SQLAlchemy==1.3.23
+    Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1106.db
 commands =
@@ -69,8 +69,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=1.10.8, <2.0.0
-    SQLAlchemy==1.3.23 
-	Flask-SQLAlchemy==2.4.4
+    SQLAlchemy==1.3.23
+    Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1108.db
 commands =
@@ -82,8 +82,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=2.0.0
-    SQLAlchemy==1.3.23 
-	Flask-SQLAlchemy==2.4.4
+    SQLAlchemy==1.3.23
+    Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow2.db
 commands =
@@ -96,8 +96,8 @@ deps =
     pytest-cov
     apache-airflow[kubernetes] >=1.10.0, <=1.10.6
     werkzeug<1.0.0
-    SQLAlchemy==1.3.23 
-	Flask-SQLAlchemy==2.4.4
+    SQLAlchemy==1.3.23
+    Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1106.db
 commands =
@@ -109,8 +109,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=1.10.8, <2.0.0
-    SQLAlchemy==1.3.23 
-	Flask-SQLAlchemy==2.4.4
+    SQLAlchemy==1.3.23
+    Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow1108.db
 commands =
@@ -122,8 +122,8 @@ deps =
     pytest
     pytest-cov
     apache-airflow[kubernetes] >=2.0.0
-    SQLAlchemy==1.3.23 
-	Flask-SQLAlchemy==2.4.4
+    SQLAlchemy==1.3.23
+    Flask-SQLAlchemy==2.4.4
 setenv =
     AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///airflow2.db
 commands =


### PR DESCRIPTION
Tests were failing because of this issue with sqlalchemy. Pinning the version to get around it for now. 

https://stackoverflow.com/questions/66774109/install-airflow-importerror-no-module-named-clsregistry