### PR TITLE
Support response_check callable in HttpSensor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex \
     /usr/share/doc \
     /usr/share/doc-base
 
-RUN pip install apache-airflow==${AIRFLOW_VERSION}
+RUN pip install apache-airflow[http]==${AIRFLOW_VERSION}
 ADD . /
 RUN pip install -e .
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -179,6 +179,7 @@ class DagBuilder:
         return dag_params
 
     # pylint: disable=too-many-branches
+    # pylint: disable=too-many-statements
     @staticmethod
     def make_task(operator: str, task_params: Dict[str, Any]) -> BaseOperator:
         """

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ VERSION = None
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-REQUIRED = ["apache-airflow[kubernetes]>=1.10.0", "pyyaml", "packaging"]
+REQUIRED = ["apache-airflow[http,kubernetes]>=1.10.0", "pyyaml", "packaging"]
 DEV_REQUIRED = ["black", "pytest", "pylint", "pytest-cov", "tox"]
 
 try:

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
 deps = 
     pytest
     pytest-cov
-    apache-airflow[cncf.kubernetes] >=2.0.0
+    apache-airflow[http,cncf.kubernetes] >=2.0.0
     SQLAlchemy==1.3.23
     Flask-SQLAlchemy==2.4.4
 setenv =
@@ -81,7 +81,7 @@ commands =
 deps = 
     pytest
     pytest-cov
-    apache-airflow[cncf.kubernetes] >=2.0.0
+    apache-airflow[http,cncf.kubernetes] >=2.0.0
     SQLAlchemy==1.3.23
     Flask-SQLAlchemy==2.4.4
 setenv =
@@ -121,7 +121,7 @@ commands =
 deps = 
     pytest
     pytest-cov
-    apache-airflow[cncf.kubernetes] >=2.0.0
+    apache-airflow[http,cncf.kubernetes] >=2.0.0
     SQLAlchemy==1.3.23
     Flask-SQLAlchemy==2.4.4
 setenv =


### PR DESCRIPTION
I have tested it for both success and failure of the sensor. This is the DAG YAML.

```
    task_3:
      operator: airflow.providers.http.sensors.http.HttpSensor
      task_id: 'http_sensor'
      http_conn_id: 'test-http'
      endpoint: ''
      method: 'GET'
      headers: 
        header1: 'value1'
      response_check_name: check_sensor
      response_check_file: /opt/airflow/dags/repo/dags/example1/http_conn.py
      poke_interval: 5
      timeout: 12        
      dependencies: [task_1]
```
