### PR TITLE
Support python_callable lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,35 @@ And this DAG will be generated and ready to run in Airflow!
 
 ![screenshot](/img/example_dag.png)
 
+## Notes
+
+### HttpSensor (since 0.10.0)
+
+The package `airflow.sensors.http_sensor` works with all supported versions of Airflow. In Airflow 2.0+, the new package name can be used in the operator value: `airflow.providers.http.sensors.http`
+
+The following example shows `response_check` logic in a python file:
+
+```yaml
+task_2:
+      operator: airflow.sensors.http_sensor.HttpSensor
+      http_conn_id: 'test-http'
+      method: 'GET'
+      response_check_name: check_sensor
+      response_check_file: /path/to/example1/http_conn.py
+      dependencies: [task_1]
+```
+
+The `response_check` logic can also be provided as a lambda:
+
+```yaml
+task_2:
+      operator: airflow.sensors.http_sensor.HttpSensor
+      http_conn_id: 'test-http'
+      method: 'GET'
+      response_check_lambda: 'lambda response: "ok" in reponse.text'
+      dependencies: [task_1]
+```
+
 ## Benefits
 
 * Construct DAGs without knowing Python

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -211,21 +211,31 @@ class DagBuilder:
                 del task_params["python_callable_file"]
 
             if operator_obj in [HttpSensor]:
-                if not task_params.get("response_check_name") and not task_params.get(
-                    "response_check_file"
-                ):
+                if not (task_params.get("response_check_name") and task_params.get(
+                    "response_check_file")) and not task_params.get(
+                        "response_check_lambda"
+                    ):
                     raise Exception(
                         "Failed to create task. HttpSensor requires \
-                        `response_check_name` and `response_check_file` parameters."
+                        `response_check_name` and `response_check_file` parameters \
+                        or `response_check_lambda` parameter."
                     )
-                task_params["response_check"]: Callable = utils.get_python_callable(
-                    task_params["response_check_name"],
-                    task_params["response_check_file"],
-                )
-                # remove dag-factory specific parameters
-                # Airflow 2.0 doesn't allow these to be passed to operator
-                del task_params["response_check_name"]
-                del task_params["response_check_file"]
+                if task_params.get("response_check_file"):
+                    task_params["response_check"]: Callable = utils.get_python_callable(
+                        task_params["response_check_name"],
+                        task_params["response_check_file"],
+                    )
+                    # remove dag-factory specific parameters
+                    # Airflow 2.0 doesn't allow these to be passed to operator
+                    del task_params["response_check_name"]
+                    del task_params["response_check_file"]
+                else:
+                    task_params["response_check"]: Callable = utils.get_python_callable_lambda(
+                        task_params["response_check_lambda"],
+                    )
+                    # remove dag-factory specific parameters
+                    # Airflow 2.0 doesn't allow these to be passed to operator
+                    del task_params["response_check_lambda"]
 
             # KubernetesPodOperator
             if operator_obj == KubernetesPodOperator:

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -451,7 +451,9 @@ class DagBuilder:
             if not os.path.isabs(dag_params.get("doc_md_file_path")):
                 raise Exception("`doc_md_file_path` must be absolute path")
 
-            with open(dag_params.get("doc_md_file_path"), "r") as file:
+            with open(
+                dag_params.get("doc_md_file_path"), "r", encoding="utf-8"
+            ) as file:
                 dag.doc_md = file.read()
 
         if dag_params.get("doc_md_python_callable_file") and dag_params.get(

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -211,10 +211,10 @@ class DagBuilder:
                 del task_params["python_callable_file"]
 
             if operator_obj in [HttpSensor]:
-                if not (task_params.get("response_check_name") and task_params.get(
-                    "response_check_file")) and not task_params.get(
-                        "response_check_lambda"
-                    ):
+                if not (
+                    task_params.get("response_check_name")
+                    and task_params.get("response_check_file")
+                ) and not task_params.get("response_check_lambda"):
                     raise Exception(
                         "Failed to create task. HttpSensor requires \
                         `response_check_name` and `response_check_file` parameters \
@@ -230,7 +230,9 @@ class DagBuilder:
                     del task_params["response_check_name"]
                     del task_params["response_check_file"]
                 else:
-                    task_params["response_check"]: Callable = utils.get_python_callable_lambda(
+                    task_params[
+                        "response_check"
+                    ]: Callable = utils.get_python_callable_lambda(
                         task_params["response_check_lambda"],
                     )
                     # remove dag-factory specific parameters

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -54,7 +54,8 @@ class DagFactory:
         # pylint: disable=consider-using-with
         try:
             config: Dict[str, Any] = yaml.load(
-                stream=open(config_filepath, "r"), Loader=yaml.FullLoader
+                stream=open(config_filepath, "r", encoding="utf-8"),
+                Loader=yaml.FullLoader,
             )
         except Exception as err:
             raise Exception("Invalid DAG Factory config file") from err

--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -3,6 +3,8 @@ import importlib.util
 import os
 import re
 import sys
+import ast
+import types
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any, AnyStr, Dict, Match, Optional, Pattern, Union
@@ -126,6 +128,27 @@ def get_python_callable(python_callable_name, python_callable_file):
     spec.loader.exec_module(module)
     sys.modules[module_name] = module
     python_callable = getattr(module, python_callable_name)
+
+    return python_callable
+
+def get_python_callable_lambda(lambda_expr):
+    """
+    Uses lambda expression in a string to create a valid callable
+    for use in operators/sensors.
+
+    :param lambda_expr: the lambda expression to be converted
+    :type lambda_expr:  str
+    :returns: python callable
+    :type: callable
+    """
+
+    tree = ast.parse(source)
+    print(type(tree.body[0]))
+    if len(tree.body) != 1 or not isinstance(tree.body[0], ast.Expr):
+        raise Exception('`lambda_expr` must be a single lambda')
+    # the second parameter below is used only for logging
+    co = compile(tree, 'lambda_expr_to_callable.py', 'exec')
+    python_callable = types.LambdaType(co.co_consts[0], {})
 
     return python_callable
 

--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -142,7 +142,7 @@ def get_python_callable_lambda(lambda_expr):
     :type: callable
     """
 
-    tree = ast.parse(source)
+    tree = ast.parse(lambda_expr)
     print(type(tree.body[0]))
     if len(tree.body) != 1 or not isinstance(tree.body[0], ast.Expr):
         raise Exception('`lambda_expr` must be a single lambda')

--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -131,6 +131,7 @@ def get_python_callable(python_callable_name, python_callable_file):
 
     return python_callable
 
+
 def get_python_callable_lambda(lambda_expr):
     """
     Uses lambda expression in a string to create a valid callable
@@ -143,12 +144,11 @@ def get_python_callable_lambda(lambda_expr):
     """
 
     tree = ast.parse(lambda_expr)
-    print(type(tree.body[0]))
     if len(tree.body) != 1 or not isinstance(tree.body[0], ast.Expr):
-        raise Exception('`lambda_expr` must be a single lambda')
+        raise Exception("`lambda_expr` must be a single lambda")
     # the second parameter below is used only for logging
-    co = compile(tree, 'lambda_expr_to_callable.py', 'exec')
-    python_callable = types.LambdaType(co.co_consts[0], {})
+    code = compile(tree, "lambda_expr_to_callable.py", "exec")
+    python_callable = types.LambdaType(code.co_consts[0], {})
 
     return python_callable
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -143,6 +143,57 @@ def test_get_python_callable_invalid_path():
         utils.get_python_callable(python_callable_name, python_callable_file)
 
 
+def test_get_python_callable_missing_param_file():
+    python_callable_file = None
+    python_callable_name = "print_test"
+
+    with pytest.raises(Exception):
+        utils.get_python_callable(python_callable_name, python_callable_file)
+
+
+def test_get_python_callable_missing_param_name():
+    python_callable_file = "/not/absolute/path"
+    python_callable_name = None
+
+    with pytest.raises(Exception):
+        utils.get_python_callable(python_callable_name, python_callable_file)
+
+
+def test_get_python_callable_lambda_valid():
+    lambda_expr = "lambda a: a"
+
+    python_callable = utils.get_python_callable_lambda(
+        lambda_expr
+    )
+
+    assert callable(python_callable)
+
+
+def test_get_python_callable_lambda_works():
+    lambda_expr = "lambda a: a"
+
+    python_callable = utils.get_python_callable_lambda(
+        lambda_expr
+    )
+
+    assert callable(python_callable)
+    assert python_callable("xyz") == "xyz"
+    assert python_callable(5) == 5
+
+
+def test_get_python_callable_lambda_invalid_expr():
+    lambda_expr = "invalid lambda expr"
+
+    with pytest.raises(Exception):
+        utils.get_python_callable_lambda(lambda_expr)
+
+
+def test_get_python_callable_lambda_missing_param():
+    lambda_expr = None
+
+    with pytest.raises(Exception):
+        utils.get_python_callable_lambda(lambda_expr)
+
 def test_get_start_date_date_string():
     expected = datetime.datetime(2018, 2, 1, 0, 0, tzinfo=UTC)
     actual = utils.get_datetime("2018-02-01")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -136,7 +136,7 @@ def test_get_python_callable_valid():
 
 
 def test_get_python_callable_invalid_path():
-    python_callable_file = "/not/absolute/path"
+    python_callable_file = "not/absolute/path"
     python_callable_name = "print_test"
 
     with pytest.raises(Exception):
@@ -183,6 +183,15 @@ def test_get_python_callable_lambda_works():
 
 def test_get_python_callable_lambda_invalid_expr():
     lambda_expr = "invalid lambda expr"
+
+    with pytest.raises(Exception):
+        utils.get_python_callable_lambda(lambda_expr)
+
+def test_get_python_callable_non_lambda_valid_expr():
+    lambda_expr = """
+    def fun():
+        print('hello')
+    """
 
     with pytest.raises(Exception):
         utils.get_python_callable_lambda(lambda_expr)


### PR DESCRIPTION
Make the following possible where we have python_callable. This PR implements it only for HttpSensor, but the new utility method can be used to enable it at other places python_callable is used. It can be done via a separate PR. 

```
task_2:
      operator: airflow.sensors.http_sensor.HttpSensor
      http_conn_id: 'test-http'
      method: 'GET'
      response_check_lambda: 'lambda response: "ok" in reponse.text'
      dependencies: [task_1]
```