### PR TITLE
Allow providing python callback through config

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -195,21 +195,25 @@ class DagBuilder:
             raise Exception(f"Failed to import operator: {operator}") from err
         try:
             if operator_obj in [PythonOperator, BranchPythonOperator]:
-                if not task_params.get("python_callable_name") and not task_params.get(
-                    "python_callable_file"
-                ):
+                if not task_params.get("python_callable") and not \
+                    task_params.get("python_callable_name") and not \
+                    task_params.get("python_callable_file"):
                     raise Exception(
                         "Failed to create task. PythonOperator and BranchPythonOperator requires \
-                        `python_callable_name` and `python_callable_file` parameters."
+                        `python_callable_name` and `python_callable_file` "
+                        "parameters.\nOptionally you can load python_callable "
+                        "from a file. with the special pyyaml notation:\n"
+                        "  python_callable_file: !!python/name:my_module.my_func"
                     )
-                task_params["python_callable"]: Callable = utils.get_python_callable(
-                    task_params["python_callable_name"],
-                    task_params["python_callable_file"],
-                )
-                # remove dag-factory specific parameters
-                # Airflow 2.0 doesn't allow these to be passed to operator
-                del task_params["python_callable_name"]
-                del task_params["python_callable_file"]
+                if not task_params.get("python_callable"): 
+                    task_params["python_callable"]: Callable = utils.get_python_callable(
+                        task_params["python_callable_name"],
+                        task_params["python_callable_file"],
+                    )
+                    # remove dag-factory specific parameters
+                    # Airflow 2.0 doesn't allow these to be passed to operator
+                    del task_params["python_callable_name"]
+                    del task_params["python_callable_file"]
 
             # Check for the custom success and failure callables in SqlSensor. These are considered
             # optional, so no failures in case they aren't found. Note: there's no reason to

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -195,9 +195,11 @@ class DagBuilder:
             raise Exception(f"Failed to import operator: {operator}") from err
         try:
             if operator_obj in [PythonOperator, BranchPythonOperator]:
-                if not task_params.get("python_callable") and not \
-                    task_params.get("python_callable_name") and not \
-                    task_params.get("python_callable_file"):
+                if (
+                    not task_params.get("python_callable")
+                    and not task_params.get("python_callable_name")
+                    and not task_params.get("python_callable_file")
+                ):
                     raise Exception(
                         "Failed to create task. PythonOperator and BranchPythonOperator requires \
                         `python_callable_name` and `python_callable_file` "
@@ -205,8 +207,10 @@ class DagBuilder:
                         "from a file. with the special pyyaml notation:\n"
                         "  python_callable_file: !!python/name:my_module.my_func"
                     )
-                if not task_params.get("python_callable"): 
-                    task_params["python_callable"]: Callable = utils.get_python_callable(
+                if not task_params.get("python_callable"):
+                    task_params[
+                        "python_callable"
+                    ]: Callable = utils.get_python_callable(
                         task_params["python_callable_name"],
                         task_params["python_callable_file"],
                     )


### PR DESCRIPTION
There's a couple cases we might want to provide a python callback through config.
First one when we build the config ourselves dinamically and we provide a dict to the
Dagfactory. Another is loading straight from pure yaml like so
```yaml
my_dag:
  tasks:
    run_my_function:
      operator: airflow.operators.python.PythonOperator
      python_callable: !!python/name:my_module.my_function
```

This is linked to the issue #104 