### PR TITLE
fix: add params to DAG initialization

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -515,9 +515,7 @@ class DagBuilder:
             "is_paused_upon_creation", None
         )
 
-        dag_kwargs["params"] = dag_params.get(
-            "params", None
-        )
+        dag_kwargs["params"] = dag_params.get("params", None)
 
         dag: DAG = DAG(**dag_kwargs)
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -515,6 +515,10 @@ class DagBuilder:
             "is_paused_upon_creation", None
         )
 
+        dag_kwargs["params"] = dag_params.get(
+            "params", None
+        )
+
         dag: DAG = DAG(**dag_kwargs)
 
         if dag_params.get("doc_md_file_path"):


### PR DESCRIPTION
Allow params to be specified in the yaml

YAML definition.

```yaml
params:
    key: value
```
This translates to 
```python
DAG(...,params={...})
```
Reference : https://github.com/apache/airflow/blob/main/airflow/models/dag.py#L229