### PR TITLE
fix: add custom timetable to DAG intialization

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -12,6 +12,7 @@ from airflow.models import BaseOperator
 from airflow.operators.python_operator import PythonOperator, BranchPythonOperator
 from airflow.sensors.http_sensor import HttpSensor
 from airflow.sensors.sql_sensor import SqlSensor
+from airflow.timetables.base import Timetable
 from airflow.utils.module_loading import import_string
 from airflow import __version__ as AIRFLOW_VERSION
 
@@ -180,6 +181,24 @@ class DagBuilder:
         except KeyError as err:
             raise Exception(f"{self.dag_name} config is missing start_date") from err
         return dag_params
+
+    @staticmethod
+    def make_timetable(timetable: str, timetable_params: Dict[str, Any]) -> Timetable:
+        """
+        Takes a custom timetable and params and creates an instance of that timetable.
+
+        :returns instance of timetable object
+        """
+        try:
+            # class is a Callable https://stackoverflow.com/a/34578836/3679900
+            timetable_obj: Callable[..., Timetable] = import_string(timetable)
+        except Exception as err:
+            raise Exception(f"Failed to import timetable {timetable} due to: {err}") from err
+        try:
+            schedule: Timetable = timetable_obj(**timetable_params)
+        except Exception as err:
+            raise Exception(f"Failed to create {timetable_obj} due to: {err}") from err
+        return schedule
 
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-statements
@@ -472,9 +491,10 @@ class DagBuilder:
 
         dag_kwargs["dag_id"] = dag_params["dag_id"]
 
-        dag_kwargs["schedule_interval"] = dag_params.get(
-            "schedule_interval", timedelta(days=1)
-        )
+        if not dag_params.get("timetable"):
+            dag_kwargs["schedule_interval"] = dag_params.get(
+                "schedule_interval", timedelta(days=1)
+            )
 
         if version.parse(AIRFLOW_VERSION) >= version.parse("1.10.11"):
             dag_kwargs["description"] = dag_params.get("description", None)
@@ -485,6 +505,12 @@ class DagBuilder:
             dag_kwargs["max_active_tasks"] = dag_params.get(
                 "max_active_tasks",
                 configuration.conf.getint("core", "max_active_tasks_per_dag"),
+            )
+
+            timetable_args = dag_params.get("timetable")
+            dag_kwargs["timetable"] = DagBuilder.make_timetable(
+                timetable_args.get("callable"),
+                timetable_args.get("params")
             )
         else:
             dag_kwargs["concurrency"] = dag_params.get(

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -40,10 +40,15 @@ from dagfactory import utils
 if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
     from airflow.sensors.python import PythonSensor
     from airflow.utils.task_group import TaskGroup
-    from airflow.timetables.base import Timetable
 else:
     TaskGroup = None
     PythonSensor = None
+# pylint: disable=ungrouped-imports,invalid-name
+
+# TimeTable is introduced in Airflow 2.2.0
+if version.parse(AIRFLOW_VERSION) >= version.parse("2.2.0"):
+    from airflow.timetables.base import Timetable
+else:
     Timetable = None
 # pylint: disable=ungrouped-imports,invalid-name
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -193,7 +193,9 @@ class DagBuilder:
             # class is a Callable https://stackoverflow.com/a/34578836/3679900
             timetable_obj: Callable[..., Timetable] = import_string(timetable)
         except Exception as err:
-            raise Exception(f"Failed to import timetable {timetable} due to: {err}") from err
+            raise Exception(
+                f"Failed to import timetable {timetable} due to: {err}"
+            ) from err
         try:
             schedule: Timetable = timetable_obj(**timetable_params)
         except Exception as err:
@@ -510,8 +512,7 @@ class DagBuilder:
             if dag_params.get("timetable"):
                 timetable_args = dag_params.get("timetable")
                 dag_kwargs["timetable"] = DagBuilder.make_timetable(
-                    timetable_args.get("callable"),
-                    timetable_args.get("params")
+                    timetable_args.get("callable"), timetable_args.get("params")
                 )
         else:
             dag_kwargs["concurrency"] = dag_params.get(

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -507,11 +507,12 @@ class DagBuilder:
                 configuration.conf.getint("core", "max_active_tasks_per_dag"),
             )
 
-            timetable_args = dag_params.get("timetable")
-            dag_kwargs["timetable"] = DagBuilder.make_timetable(
-                timetable_args.get("callable"),
-                timetable_args.get("params")
-            )
+            if dag_params.get("timetable"):
+                timetable_args = dag_params.get("timetable")
+                dag_kwargs["timetable"] = DagBuilder.make_timetable(
+                    timetable_args.get("callable"),
+                    timetable_args.get("params")
+                )
         else:
             dag_kwargs["concurrency"] = dag_params.get(
                 "concurrency", configuration.conf.getint("core", "dag_concurrency")

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -9,11 +9,16 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.sensors.http_sensor import HttpSensor
 from airflow.sensors.sql_sensor import SqlSensor
-from airflow.timetables.interval import CronDataIntervalTimetable
 from airflow import __version__ as AIRFLOW_VERSION
 from packaging import version
 
 from dagfactory import dagbuilder
+
+if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
+    from airflow.timetables.interval import CronDataIntervalTimetable
+else:
+    Timetable = None
+# pylint: disable=ungrouped-imports,invalid-name
 
 here = os.path.dirname(__file__)
 
@@ -537,15 +542,16 @@ def test_make_task_with_callback():
 
 
 def test_make_timetable():
-    td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
-    timetable = "airflow.timetables.interval.CronDataIntervalTimetable"
-    timetable_params = {
-        "cron": "0 8,16 * * 1-5",
-        "timezone": "UTC"
-    }
-    actual = td.make_timetable(timetable, timetable_params)
-    assert actual.periodic
-    assert actual.can_run
+    if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
+        td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
+        timetable = "airflow.timetables.interval.CronDataIntervalTimetable"
+        timetable_params = {
+            "cron": "0 8,16 * * 1-5",
+            "timezone": "UTC"
+        }
+        actual = td.make_timetable(timetable, timetable_params)
+        assert actual.periodic
+        assert actual.can_run
 
 
 def test_make_dag_with_callback():

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -9,6 +9,7 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.sensors.http_sensor import HttpSensor
 from airflow.sensors.sql_sensor import SqlSensor
+from airflow.timetables.interval import CronDataIntervalTimetable
 from airflow import __version__ as AIRFLOW_VERSION
 from packaging import version
 
@@ -533,6 +534,18 @@ def test_make_task_with_callback():
     if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
         assert callable(actual.on_execute_callback)
     assert callable(actual.on_retry_callback)
+
+
+def test_make_timetable():
+    td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
+    timetable = "airflow.timetables.interval.CronDataIntervalTimetable"
+    timetable_params = {
+        "cron": "0 8,16 * * 1-5",
+        "timezone": "UTC"
+    }
+    actual = td.make_timetable(timetable, timetable_params)
+    assert actual.periodic
+    assert actual.can_run
 
 
 def test_make_dag_with_callback():


### PR DESCRIPTION
Add timetable support, a feature in Airflow versions 2.2.0 and up.

The yaml configuration will take in a value "timetable" which accepts two key values:
1. callable - the python module we are referencing for the timetable
2. params - the params for the python module

Example Yaml Definition:
```
  timetable:
    callable: custompackage.timetables.CustomTimeTable
    params:
      cron: "0 8,16 * * 1-5"
      holiday: "christmas"
```

This translates to
`DAG(...,timetable=CustomTimeTable(cron="0 8,16 * * 1-5", holiday="christmas"))`

Reference: 
https://airflow.apache.org/docs/apache-airflow/stable/howto/timetable.html
https://airflow.apache.org/docs/apache-airflow/stable/concepts/timetable.html