### PR TITLE
Add function to scan recursively searching for yaml DAGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ dag_factory.generate_dags(globals())
 
 And this DAG will be generated and ready to run in Airflow!
 
+If you have several configuration files you can improt them like this:
+
+```python
+# 'airflow' word is required for the dagbag to parse this file
+from dagfactory import load_yaml_dags
+
+load_yaml_dags(globals_dict=globals(), suffix=['dag.yaml'])
+```
+
 ![screenshot](/img/example_dag.png)
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ dag_factory.generate_dags(globals())
 
 And this DAG will be generated and ready to run in Airflow!
 
-If you have several configuration files you can improt them like this:
+If you have several configuration files you can import them like this:
 
 ```python
 # 'airflow' word is required for the dagbag to parse this file

--- a/dagfactory/__init__.py
+++ b/dagfactory/__init__.py
@@ -1,2 +1,3 @@
 """Modules and methods to export for easier access"""
 from .dagfactory import DagFactory
+from .utils import load_yaml_dags

--- a/dagfactory/__init__.py
+++ b/dagfactory/__init__.py
@@ -1,3 +1,2 @@
 """Modules and methods to export for easier access"""
-from .dagfactory import DagFactory
-from .utils import load_yaml_dags
+from .dagfactory import DagFactory, load_yaml_dags

--- a/dagfactory/__version__.py
+++ b/dagfactory/__version__.py
@@ -1,2 +1,2 @@
 """Module contains the version of dag-factory"""
-__version__ = "0.15.0"
+__version__ = "0.16.0"

--- a/dagfactory/dagfactory.py
+++ b/dagfactory/dagfactory.py
@@ -179,7 +179,7 @@ def load_yaml_dags(
     :param globals_dict: The globals() from the file used to generate DAGs
     :dags_folder: Path to the folder you want to get recursively scanned
     :suffix: file suffix to filter `in` what files to scan for dags
-    xº"""
+    """
     # chain all file suffixes in a single iterator
     logging.info("Loading DAGs from %s", dags_folder)
     if suffix is None:
@@ -194,4 +194,3 @@ def load_yaml_dags(
         config_file_abs_path = str(config_file_path.absolute())
         DagFactory(config_file_abs_path).generate_dags(globals_dict)
         logging.info("DAG loaded: %s", config_file_path)
-

--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -112,9 +112,9 @@ def get_python_callable(python_callable_name, python_callable_file):
 
     :param python_callable_name: name of python callable to be imported
     :type python_callable_name:  str
-    :param python_callable_file: aboslute path of python file with callable
+    :param python_callable_file: absolute path of python file with callable
     :type python_callable_file: str
-    :returns: python calllable
+    :returns: python callable
     :type: callable
     """
 

--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -180,28 +180,26 @@ def load_yaml_dags(
     The dags folder is defaulted to the airflow dags folder if unspecified.
     And the prefix is set to yaml/yml by default. However, it can be
     interesting to load only a subset by setting a different suffix.
-    
+
     :param globals: The globals() from the file used to generate DAGs. The dag_id
         must be passed into globals() for Airflow to import
     :dags_folder: Path to the folder you want to get recursively scanned for DAGs
     :suffix: file suffis to filter `in` what files to scan for dags
     xº"""
     # chain all file suffixes in a single iterator
-    logging.info(f'Loading DAGs from {dags_folder}')
+    logging.info(f"Loading DAGs from {dags_folder}")
     if suffix is None:
-        suffix = ['.yaml', '.yml']
+        suffix = [".yaml", ".yml"]
     candidate_dag_files = []
     for suf in suffix:
         candidate_dag_files = chain(
-            candidate_dag_files,
-            Path(dags_folder).rglob(f'*{suf}')
+            candidate_dag_files, Path(dags_folder).rglob(f"*{suf}")
         )
 
     for config_file_path in candidate_dag_files:
         try:
             config_file_abs_path = str(config_file_path.absolute())
             DagFactory(config_file_abs_path).generate_dags(globals_dict)
-            logging.info(f'DAG loaded: {config_file_path}')
+            logging.info(f"DAG loaded: {config_file_path}")
         except BaseException as err:
-            raise AirflowException(
-                f"Failed to load {config_file_path} — {err}")
+            raise AirflowException(f"Failed to load {config_file_path} — {err}")

--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -5,16 +5,11 @@ import os
 import re
 import sys
 import types
-import logging
 from datetime import date, datetime, timedelta
-from itertools import chain
 from typing import Any, AnyStr, Dict, Match, Optional, Pattern, Union
 from pathlib import Path
-from airflow.configuration import conf as airflow_conf
 
 import pendulum
-
-from dagfactory import DagFactory
 
 
 def get_datetime(
@@ -172,38 +167,3 @@ def check_dict_key(item_dict: Dict[str, Any], key: str) -> bool:
     :type: bool
     """
     return bool(key in item_dict and item_dict[key] is not None)
-
-
-def load_yaml_dags(
-    globals_dict: Dict[str, Any],
-    dags_folder: str = airflow_conf.get("core", "dags_folder"),
-    suffix=None,
-):
-    """
-    Loads all the yaml/yml files in the dags folder
-
-    The dags folder is defaulted to the airflow dags folder if unspecified.
-    And the prefix is set to yaml/yml by default. However, it can be
-    interesting to load only a subset by setting a different suffix.
-
-    :param globals: The globals() from the file used to generate DAGs. The
-    dag_id
-        must be passed into globals() for Airflow to import
-    :dags_folder: Path to the folder you want to get recursively scanned for
-    DAGs
-    :suffix: file suffis to filter `in` what files to scan for dags
-    xº"""
-    # chain all file suffixes in a single iterator
-    logging.info("Loading DAGs from %s", dags_folder)
-    if suffix is None:
-        suffix = [".yaml", ".yml"]
-    candidate_dag_files = []
-    for suf in suffix:
-        candidate_dag_files = chain(
-            candidate_dag_files, Path(dags_folder).rglob(f"*{suf}")
-        )
-
-    for config_file_path in candidate_dag_files:
-        config_file_abs_path = str(config_file_path.absolute())
-        DagFactory(config_file_abs_path).generate_dags(globals_dict)
-        logging.info("DAG loaded: %s", config_file_path)

--- a/tests/fixtures/dag_factory_task_group.yml
+++ b/tests/fixtures/dag_factory_task_group.yml
@@ -26,7 +26,7 @@ example_dag:
     task_3:
       operator: airflow.operators.python_operator.PythonOperator
       python_callable_name: print_hello
-      python_callable_file: /Users/buraky/Projects/dag-factory/examples/print_hello.py
+      python_callable_file: examples/print_hello.py
       task_group_name: task_group_1
       dependencies: [task_2]
     task_4:

--- a/tests/test_dagfactory.py
+++ b/tests/test_dagfactory.py
@@ -1,6 +1,6 @@
-from logging import error
 import os
 import datetime
+
 import pytest
 from airflow.models.variable import Variable
 from packaging import version
@@ -8,7 +8,7 @@ from airflow import __version__ as AIRFLOW_VERSION
 
 here = os.path.dirname(__file__)
 
-from dagfactory import dagfactory
+from dagfactory import dagfactory, load_yaml_dags
 
 TEST_DAG_FACTORY = os.path.join(here, "fixtures/dag_factory.yml")
 INVALID_YAML = os.path.join(here, "fixtures/invalid_yaml.yml")
@@ -429,3 +429,20 @@ def test_set_callback_after_loading_config():
         config=DAG_FACTORY_CONFIG
     ).build_dags
     td.generate_dags(globals())
+
+
+def test_load_yaml_dags_fail():
+    with pytest.raises(Exception):
+        load_yaml_dags(
+            globals_dict= globals(),
+            dags_folder="tests/fixtures",
+            suffix=["invalid_yaml.yml"],
+        )
+
+
+def test_load_yaml_dags_succeed():
+    load_yaml_dags(
+        globals_dict= globals(),
+        dags_folder="tests/fixtures",
+        suffix=["dag_factory_variables_as_arguments.yml"],
+    )


### PR DESCRIPTION
Hello! I've got this recurring use case where I scan my  DAGs folder recursively looking for DAGs defined in yaml files.

B default this prefixes are `.yml` and `.yaml`. But I found that filtering out files not containing DAGs is convenient. You can do so setting the. `prefix=['dag.yaml']` to match files like `my_dinigo_dag.yaml` and `my_ajbosco.dag.yaml`. But not `operator_config.yaml`.  The scan path defaults to the `dag folder` extracted from running airflow configuration.

I am using this on my package, but it is a nice addition to the library and I thought it belonged here.