### PR TITLE
fix import errors when using Airflow 2.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   
 ## Installation
 
-To install *dag-factory* run `pip install dag-factory`. It requires Python 3.6.0+ and Apache Airflow 1.10+.
+To install *dag-factory* run `pip install dag-factory`. It requires Python 3.6.0+ and Apache Airflow 2.0+.
 
 ## Usage
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -7,13 +7,33 @@ from copy import deepcopy
 
 from airflow import DAG, configuration
 from airflow.models import Variable
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 from airflow.models import BaseOperator
-from airflow.operators.python_operator import PythonOperator, BranchPythonOperator
-from airflow.sensors.http_sensor import HttpSensor
-from airflow.sensors.sql_sensor import SqlSensor
 from airflow.utils.module_loading import import_string
-from airflow import __version__ as AIRFLOW_VERSION
+
+try:
+    from airflow import version as AIRFLOW_VERSION
+except ImportError:
+    from airflow import __version__ as AIRFLOW_VERSION
+
+
+# python operators were moved in 2.4
+try:
+    from airflow.operators.python import PythonOperator, BranchPythonOperator
+except ImportError:
+    from airflow.operators.python_operator import PythonOperator, BranchPythonOperator
+
+
+# http sensor was moved in 2.4
+try:
+    from airflow.providers.http.sensors.http import HttpSensor
+except ImportError:
+    from airflow.sensors.http_sensor import HttpSensor
+
+# sql sensor was moved in 2.4
+try:
+    from airflow.providers.common.sql.sensors.sql import SqlSensor
+except ImportError:
+    from airflow.sensors.sql_sensor import SqlSensor
 
 # kubernetes operator
 try:
@@ -22,12 +42,14 @@ try:
     from airflow.kubernetes.volume_mount import VolumeMount
     from airflow.kubernetes.volume import Volume
     from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
+    from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 except ImportError:
     from airflow.contrib.kubernetes.secret import Secret
     from airflow.contrib.kubernetes.pod import Port
     from airflow.contrib.kubernetes.volume_mount import VolumeMount
     from airflow.contrib.kubernetes.volume import Volume
     from airflow.contrib.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
+    from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 from kubernetes.client.models import V1Pod, V1Container
 from packaging import version
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -11,10 +11,9 @@ from airflow.models import BaseOperator
 from airflow.utils.module_loading import import_string
 
 try:
-    from airflow import version as AIRFLOW_VERSION
+    from airflow.version import version as AIRFLOW_VERSION
 except ImportError:
     from airflow import __version__ as AIRFLOW_VERSION
-
 
 # python operators were moved in 2.4
 try:

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -30,9 +30,9 @@ except ImportError:
 
 # sql sensor was moved in 2.4
 try:
-    from airflow.providers.common.sql.sensors.sql import SqlSensor
-except ImportError:
     from airflow.sensors.sql_sensor import SqlSensor
+except ImportError:
+    from airflow.providers.common.sql.sensors.sql import SqlSensor
 
 # kubernetes operator
 try:

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -42,7 +42,9 @@ try:
     from airflow.kubernetes.volume_mount import VolumeMount
     from airflow.kubernetes.volume import Volume
     from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
-    from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+    from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+        KubernetesPodOperator,
+    )
 except ImportError:
     from airflow.contrib.kubernetes.secret import Secret
     from airflow.contrib.kubernetes.pod import Port

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -5,12 +5,34 @@ from unittest.mock import patch
 import pendulum
 import pytest
 from airflow import DAG
-from airflow.operators.bash_operator import BashOperator
-from airflow.operators.python_operator import PythonOperator
-from airflow.sensors.http_sensor import HttpSensor
-from airflow.sensors.sql_sensor import SqlSensor
-from airflow import __version__ as AIRFLOW_VERSION
+
 from packaging import version
+
+try:
+    from airflow.providers.http.sensors.http import HttpSensor
+except ImportError:
+    from airflow.sensors.http_sensor import HttpSensor
+
+try:
+    from airflow.providers.common.sql.sensors.sql import SqlSensor
+except ImportError:
+    from airflow.sensors.sql_sensor import SqlSensor
+
+try:
+    from airflow.operators.bash import BashOperator
+except ImportError:
+    from airflow.operators.bash_operator import BashOperator
+
+try:
+    from airflow.operators.python import PythonOperator
+except ImportError:
+    from airflow.operators.python_operator import PythonOperator
+
+try:
+    from airflow.version import version as AIRFLOW_VERSION
+except ImportError:
+    from airflow import __version__ as AIRFLOW_VERSION
+
 
 from dagfactory import dagbuilder
 

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -327,7 +327,10 @@ def test_make_http_sensor_lambda():
 
 def test_make_sql_sensor_success():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
-    operator = "airflow.sensors.sql_sensor.SqlSensor"
+    if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
+        operator = "airflow.providers.common.sql.sensors.sql.SqlSensor"
+    else:
+        operator = "airflow.sensors.sql_sensor.SqlSensor"
     task_params = {
         "task_id": "test_task",
         "conn_id": "test-sql",
@@ -343,7 +346,10 @@ def test_make_sql_sensor_success():
 
 def test_make_sql_sensor_success_lambda():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
-    operator = "airflow.sensors.sql_sensor.SqlSensor"
+    if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
+        operator = "airflow.providers.common.sql.sensors.sql.SqlSensor"
+    else:
+        operator = "airflow.sensors.sql_sensor.SqlSensor"
     task_params = {
         "task_id": "test_task",
         "conn_id": "test-sql",
@@ -358,7 +364,10 @@ def test_make_sql_sensor_success_lambda():
 
 def test_make_sql_sensor_failure():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
-    operator = "airflow.sensors.sql_sensor.SqlSensor"
+    if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
+        operator = "airflow.providers.common.sql.sensors.sql.SqlSensor"
+    else:
+        operator = "airflow.sensors.sql_sensor.SqlSensor"
     task_params = {
         "task_id": "test_task",
         "conn_id": "test-sql",
@@ -375,7 +384,10 @@ def test_make_sql_sensor_failure():
 
 def test_make_sql_sensor_failure_lambda():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
-    operator = "airflow.sensors.sql_sensor.SqlSensor"
+    if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
+        operator = "airflow.providers.common.sql.sensors.sql.SqlSensor"
+    else:
+        operator = "airflow.sensors.sql_sensor.SqlSensor"
     task_params = {
         "task_id": "test_task",
         "conn_id": "test-sql",

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -14,9 +14,9 @@ except ImportError:
     from airflow.sensors.http_sensor import HttpSensor
 
 try:
-    from airflow.providers.common.sql.sensors.sql import SqlSensor
-except ImportError:
     from airflow.sensors.sql_sensor import SqlSensor
+except ImportError:
+    from airflow.providers.common.sql.sensors.sql import SqlSensor
 
 try:
     from airflow.operators.bash import BashOperator
@@ -327,10 +327,7 @@ def test_make_http_sensor_lambda():
 
 def test_make_sql_sensor_success():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
-    if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
-        operator = "airflow.providers.common.sql.sensors.sql.SqlSensor"
-    else:
-        operator = "airflow.sensors.sql_sensor.SqlSensor"
+    operator = "airflow.sensors.sql_sensor.SqlSensor"
     task_params = {
         "task_id": "test_task",
         "conn_id": "test-sql",
@@ -346,10 +343,7 @@ def test_make_sql_sensor_success():
 
 def test_make_sql_sensor_success_lambda():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
-    if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
-        operator = "airflow.providers.common.sql.sensors.sql.SqlSensor"
-    else:
-        operator = "airflow.sensors.sql_sensor.SqlSensor"
+    operator = "airflow.sensors.sql_sensor.SqlSensor"
     task_params = {
         "task_id": "test_task",
         "conn_id": "test-sql",
@@ -364,10 +358,7 @@ def test_make_sql_sensor_success_lambda():
 
 def test_make_sql_sensor_failure():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
-    if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
-        operator = "airflow.providers.common.sql.sensors.sql.SqlSensor"
-    else:
-        operator = "airflow.sensors.sql_sensor.SqlSensor"
+    operator = "airflow.sensors.sql_sensor.SqlSensor"
     task_params = {
         "task_id": "test_task",
         "conn_id": "test-sql",
@@ -384,10 +375,7 @@ def test_make_sql_sensor_failure():
 
 def test_make_sql_sensor_failure_lambda():
     td = dagbuilder.DagBuilder("test_dag", DAG_CONFIG, DEFAULT_CONFIG)
-    if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
-        operator = "airflow.providers.common.sql.sensors.sql.SqlSensor"
-    else:
-        operator = "airflow.sensors.sql_sensor.SqlSensor"
+    operator = "airflow.sensors.sql_sensor.SqlSensor"
     task_params = {
         "task_id": "test_task",
         "conn_id": "test-sql",


### PR DESCRIPTION
The import logic has become 🍝 trying to support so many versions of Airflow. At some point, should just cut over and support the latest few versions.