### PR TITLE
Uses kubernetes client for newer airflow versions

### DIFF
--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -167,3 +167,15 @@ def check_dict_key(item_dict: Dict[str, Any], key: str) -> bool:
     :type: bool
     """
     return bool(key in item_dict and item_dict[key] is not None)
+
+def convert_to_snake_case(input_string: str) -> str:
+    """
+    Converts the string to snake case if camel case.
+
+    :param input_string: the string to be converted
+    :type input_string: str
+    :return: string converted to snake case
+    :type: str
+    """
+    # source: https://www.geeksforgeeks.org/python-program-to-convert-camel-case-string-to-snake-case/
+    return "".join("_" + i.lower() if i.isupper() else i for i in input_string).lstrip("_")


### PR DESCRIPTION
After airflow 2.5.0 a few kubernetes modules deprecated had their back compatibility removed from airflow. This PR uses the right kubernetes modules for when the airflow used is 2.5.0 or above, keeping the input format for the yaml that was previously used.