### PR TITLE
Use k8s library version as condition

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -37,7 +37,8 @@ except ImportError:
 # k8s libraries are moved in v5.0.0
 try:
     import airflow.providers.cncf.kubernetes.get_provider_info as get_provider_info
-    K8S_PROVIDER_VERSION = get_provider_info.get_provider_info()['versions'][0]
+
+    K8S_PROVIDER_VERSION = get_provider_info.get_provider_info()["versions"][0]
 except ImportError:
     K8S_PROVIDER_VERSION = "0"
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -36,7 +36,8 @@ except ImportError:
 
 # k8s libraries are moved in v5.0.0
 try:
-    from airflow.providers.cncf.kubernetes import __version__ as K8S_PROVIDER_VERSION
+    import airflow.providers.cncf.kubernetes.get_provider_info as get_provider_info
+    K8S_PROVIDER_VERSION = get_provider_info.get_provider_info()['versions'][0]
 except ImportError:
     K8S_PROVIDER_VERSION = "0"
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -36,7 +36,7 @@ except ImportError:
 
 # k8s libraries are moved in v5.0.0
 try:
-    import airflow.providers.cncf.kubernetes.get_provider_info as get_provider_info
+    from airflow.providers.cncf.kubernetes import get_provider_info
 
     K8S_PROVIDER_VERSION = get_provider_info.get_provider_info()["versions"][0]
 except ImportError:


### PR DESCRIPTION
The usage of `apache-airflow-providers-cncf-kubernetes` provider at version 5.0.0 and above is causing issues with dag-factory. 

The [existing check](https://github.com/ajbosco/dag-factory/blob/master/dagfactory/dagbuilder.py#L39) for airflow v2.5.0 or higher doesn't capture cases where the `apache-airflow-providers-cncf-kubernetes` provider is >=5.0.0 such as GCP's Composer which [moved to 5.0.0](https://cloud.google.com/composer/docs/release-notes#December_04_2022) with Airflow 2.3.4.

This check's syntax looks gnarly but matches [this other library](https://github.com/valayDave/metaflow/blob/a95b1b844b2d0d9484adf049703c7c64867ae246/metaflow/plugins/airflow/airflow_utils.py#L81)

I believe this will fix #148, as I still see this error at the latest dag-factory with Airflow 2.3.4

TESTED:
- Ran in local docker container, saw DAGs generated
- I wasn't able to add an Airflow 2.5.X test case (dependencies timed out)