### PR TITLE
Allow inheritance of KubernetesPodOperator

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -372,7 +372,7 @@ class DagBuilder:
                     del task_params["response_check_lambda"]
 
             # KubernetesPodOperator
-            if operator_obj == KubernetesPodOperator:
+            if isinstance(operator_obj, KubernetesPodOperator):
                 task_params["secrets"] = (
                     [Secret(**v) for v in task_params.get("secrets")]
                     if task_params.get("secrets") is not None


### PR DESCRIPTION
This fixes #156 
TBH potentially the same condition should be used for all operators to allow custom implementations of sensors, etc