### PR TITLE
Added render_template_as_native_obj support

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -247,6 +247,16 @@ class DagBuilder:
             else:
                 raise DagFactoryException("template_searchpath is not valid!")
 
+        if utils.check_dict_key(dag_params, "render_template_as_native_obj"):
+            if isinstance(dag_params["render_template_as_native_obj"], bool):
+                dag_params["render_template_as_native_obj"]: bool = dag_params[
+                    "render_template_as_native_obj"
+                ]
+            else:
+                raise DagFactoryException(
+                    "render_template_as_native_obj should be bool type!"
+                )
+
         try:
             # ensure that default_args dictionary contains key "start_date"
             # with "datetime" value in specified timezone
@@ -656,6 +666,10 @@ class DagBuilder:
         )
 
         dag_kwargs["template_searchpath"] = dag_params.get("template_searchpath", None)
+
+        dag_kwargs["render_template_as_native_obj"] = dag_params.get(
+            "render_template_as_native_obj", None
+        )
 
         dag_kwargs["sla_miss_callback"] = dag_params.get("sla_miss_callback", None)
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -667,9 +667,13 @@ class DagBuilder:
 
         dag_kwargs["template_searchpath"] = dag_params.get("template_searchpath", None)
 
-        dag_kwargs["render_template_as_native_obj"] = dag_params.get(
-            "render_template_as_native_obj", None
-        )
+        # Jinja NativeEnvironment support has been added in Airflow 2.1.0
+        if version.parse(AIRFLOW_VERSION) >= version.parse("2.1.0"):
+            dag_kwargs["render_template_as_native_obj"] = dag_params.get(
+                "render_template_as_native_obj", None
+            )
+        else:
+            raise DagFactoryException("render_template_as_native_obj supported only in Airflow version >= 2.1.0")
 
         dag_kwargs["sla_miss_callback"] = dag_params.get("sla_miss_callback", None)
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -673,7 +673,9 @@ class DagBuilder:
                 "render_template_as_native_obj", None
             )
         else:
-            raise DagFactoryException("render_template_as_native_obj supported only in Airflow version >= 2.1.0")
+            raise DagFactoryException(
+                "render_template_as_native_obj supported only in Airflow version >= 2.1.0"
+            )
 
         dag_kwargs["sla_miss_callback"] = dag_params.get("sla_miss_callback", None)
 

--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -672,10 +672,6 @@ class DagBuilder:
             dag_kwargs["render_template_as_native_obj"] = dag_params.get(
                 "render_template_as_native_obj", None
             )
-        else:
-            raise DagFactoryException(
-                "render_template_as_native_obj supported only in Airflow version >= 2.1.0"
-            )
 
         dag_kwargs["sla_miss_callback"] = dag_params.get("sla_miss_callback", None)
 

--- a/examples/example_dag_factory.yml
+++ b/examples/example_dag_factory.yml
@@ -22,6 +22,7 @@ example_dag:
     start_date: 2 days
   description: "this is an example dag"
   schedule_interval: "0 3 * * *"
+  render_template_as_native_obj: True
   tasks:
     task_1:
       operator: airflow.operators.bash_operator.BashOperator

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -593,6 +593,16 @@ def test_get_dag_params_with_template_searchpath():
     with pytest.raises(Exception, match=error_message):
         td.get_dag_params()
 
+    td = dagbuilder.DagBuilder("test_dag", {"template_searchpath": "./sql"}, DEFAULT_CONFIG)
+    error_message = "template_searchpath must be absolute paths"
+    with pytest.raises(Exception, match=error_message):
+        td.get_dag_params()
+
+    td = dagbuilder.DagBuilder("test_dag", {"template_searchpath": "/sql"}, DEFAULT_CONFIG)
+    error_message = "template_searchpath must be absolute paths"
+    with pytest.raises(Exception, match=error_message):
+        td.get_dag_params()
+
 
 def test_get_dag_params_with_render_template_as_native_obj():
     td = dagbuilder.DagBuilder("test_dag", {"render_template_as_native_obj": "true"}, DEFAULT_CONFIG)

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -599,7 +599,7 @@ def test_get_dag_params_with_template_searchpath():
         td.get_dag_params()
 
     td = dagbuilder.DagBuilder("test_dag", {"template_searchpath": "/sql"}, DEFAULT_CONFIG)
-    error_message = "template_searchpath must be absolute paths"
+    error_message = "template_searchpath must be existing paths"
     with pytest.raises(Exception, match=error_message):
         td.get_dag_params()
 

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -33,7 +33,6 @@ try:
 except ImportError:
     from airflow import __version__ as AIRFLOW_VERSION
 
-
 from dagfactory import dagbuilder
 
 if version.parse(AIRFLOW_VERSION) >= version.parse("2.0.0"):
@@ -63,6 +62,7 @@ DAG_CONFIG = {
     "description": "this is an example dag",
     "schedule_interval": "0 3 * * *",
     "tags": ["tag1", "tag2"],
+    "render_template_as_native_obj": True,
     "tasks": {
         "task_1": {
             "operator": "airflow.operators.bash_operator.BashOperator",
@@ -199,6 +199,7 @@ def test_get_dag_params():
         "concurrency": 1,
         "max_active_runs": 1,
         "dagrun_timeout": datetime.timedelta(seconds=600),
+        "render_template_as_native_obj": True,
         "tags": ["tag1", "tag2"],
         "tasks": {
             "task_1": {
@@ -589,5 +590,18 @@ def test_get_dag_params_with_template_searchpath():
 
     td = dagbuilder.DagBuilder("test_dag", {"template_searchpath": ["/sql"]}, DEFAULT_CONFIG)
     error_message = "template_searchpath must be existing paths"
+    with pytest.raises(Exception, match=error_message):
+        td.get_dag_params()
+
+
+def test_get_dag_params_with_render_template_as_native_obj():
+    td = dagbuilder.DagBuilder("test_dag", {"render_template_as_native_obj": "true"}, DEFAULT_CONFIG)
+    error_message = "render_template_as_native_obj should be bool type!"
+    with pytest.raises(Exception, match=error_message):
+        td.get_dag_params()
+
+    false = lambda x: print(x)
+    td = dagbuilder.DagBuilder("test_dag", {"render_template_as_native_obj": false}, DEFAULT_CONFIG)
+    error_message = "render_template_as_native_obj should be bool type!"
     with pytest.raises(Exception, match=error_message):
         td.get_dag_params()

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -605,8 +605,8 @@ def test_get_dag_params_with_template_searchpath():
         td.get_dag_params()
 
     assert utils.check_template_searchpath(123) == False
-    assert utils.check_template_searchpath("/usr/local/airflow/dags") == True
-    assert utils.check_template_searchpath(["/usr/local/airflow/dags"]) == True
+    assert utils.check_template_searchpath("/home/runner/work") == True
+    assert utils.check_template_searchpath(["/home/runner/work"]) == True
 
 
 def test_get_dag_params_with_render_template_as_native_obj():

--- a/tests/test_dagbuilder.py
+++ b/tests/test_dagbuilder.py
@@ -583,6 +583,7 @@ def test_make_dag_with_callback():
 
 
 def test_get_dag_params_with_template_searchpath():
+    from dagfactory import utils
     td = dagbuilder.DagBuilder("test_dag", {"template_searchpath": ["./sql"]}, DEFAULT_CONFIG)
     error_message = "template_searchpath must be absolute paths"
     with pytest.raises(Exception, match=error_message):
@@ -602,6 +603,10 @@ def test_get_dag_params_with_template_searchpath():
     error_message = "template_searchpath must be existing paths"
     with pytest.raises(Exception, match=error_message):
         td.get_dag_params()
+
+    assert utils.check_template_searchpath(123) == False
+    assert utils.check_template_searchpath("/usr/local/airflow/dags") == True
+    assert utils.check_template_searchpath(["/usr/local/airflow/dags"]) == True
 
 
 def test_get_dag_params_with_render_template_as_native_obj():


### PR DESCRIPTION
Added support and tests for render_template_as_native_obj.
It helps to use Jinja Templates in classic operators same as in dynamic ones, when you need python objects instead of strings