### PR TITLE
Set default value of render_template_as_native_obj by False.

### DIFF
--- a/dagfactory/dagbuilder.py
+++ b/dagfactory/dagbuilder.py
@@ -739,7 +739,7 @@ class DagBuilder:
         # Jinja NativeEnvironment support has been added in Airflow 2.1.0
         if version.parse(AIRFLOW_VERSION) >= version.parse("2.1.0"):
             dag_kwargs["render_template_as_native_obj"] = dag_params.get(
-                "render_template_as_native_obj", None
+                "render_template_as_native_obj", False
             )
 
         dag_kwargs["sla_miss_callback"] = dag_params.get("sla_miss_callback", None)


### PR DESCRIPTION
It cannot be configured from airflow.cfg and cannot be NoneType (at least in 2.5.1) so we set it False by default.