### PR TITLE
Fix to make expand task params as optional

### DIFF
--- a/dagfactory/utils.py
+++ b/dagfactory/utils.py
@@ -232,10 +232,11 @@ def get_expand_partial_kwargs(
 
     expand_kwargs: Dict[str, Union[Dict[str, Any], Any]] = {}
     partial_kwargs: Dict[str, Union[Dict[str, Any], Any]] = {}
-    for expand_key, expand_value in task_params["expand"].items():
-        expand_kwargs[expand_key] = expand_value
-    # remove dag-factory specific parameter
-    del task_params["expand"]
+    if check_dict_key(task_params, "expand"):
+        for expand_key, expand_value in task_params["expand"].items():
+            expand_kwargs[expand_key] = expand_value
+        # remove dag-factory specific parameter
+        del task_params["expand"]
     if check_dict_key(task_params, "partial"):
         for partial_key, partial_value in task_params["partial"].items():
             partial_kwargs[partial_key] = partial_value


### PR DESCRIPTION
Make expand task params as optional, so not all tasks need to provide it.  Currently, if there is no expand field in tasks YAML, it fails to generate the DAG from YAML. Also using expand creates a task mapping in airflow which doesn't not work when you want to use a branch operator to skip certain tasks based on the condition. Fix it here by making it optional.